### PR TITLE
feat: modernize Python logger namespace handling

### DIFF
--- a/README.build.md
+++ b/README.build.md
@@ -1,23 +1,51 @@
+## Python package build notes
+
+### Prerequisites
+
+```bash
 python -m pip install --upgrade build
-
-- Increase version at setup.py as package.json
-
 ```
-rm -rf dist/*
-rm -rf build/lib/oliver_framework/*;
-cp -rf python/* build/lib/oliver_framework/
+
+Increase the version number in `setup.py` before building so that package
+indexes and dependency managers can detect the new release.
+
+### Create a source and wheel distribution
+
+```bash
+rm -rf dist/
 python -m build
-git add *
-git commit -m LatestBuild#
-git push
-rm -rf sass/lib/python3.8/site-packages/oliver_framework*
-. sass/bin/activate
-pip install --upgrade git+https://github.com/jufist/oliver-framework.git
 ```
 
-# Link and quick dev
+The `python/` directory is declared as the package source in `setup.py`, so no
+additional file copies are required.
 
-In oliver-framework pip install -e . python -m build
+### Publish the build
 
-Go to target rm -rf sass/lib/python3.8/site-packages/oliver_framework\* . sass/bin/activate pip install --upgrade
-~/projects/oliver-framework/
+```bash
+git add .
+git commit -m "Build release"
+git push
+```
+
+To test the package locally before publishing, install it in a virtual
+environment:
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+python -m pip install --upgrade dist/*.whl
+```
+
+### Editable installs for development
+
+```bash
+python -m pip install --upgrade pip
+python -m pip install --upgrade -e .
+```
+
+Reinstall the package in downstream projects by activating the appropriate
+environment and running:
+
+```bash
+python -m pip install --upgrade git+https://github.com/jufist/oliver-framework.git
+```

--- a/README.md
+++ b/README.md
@@ -4,6 +4,36 @@
 
 - `yarn add git+https://github.com/jufist/oliver-framework.git`
 
+### Python package
+
+The repository also distributes a Python helper package that mirrors the
+JavaScript tooling. Install the package directly from the repository:
+
+```bash
+python -m pip install --upgrade git+https://github.com/jufist/oliver-framework.git
+```
+
+The module exposes a colour-aware logger:
+
+```python
+from oliver_framework import getlogger
+
+logger = getlogger("workers")
+logger.info("Dispatcher started")
+```
+
+The logger reads optional environment variables that can be configured in an
+`.env` file at the repository root:
+
+| Variable       | Description                                                                |
+| -------------- | -------------------------------------------------------------------------- |
+| `LOGGINGLEVEL` | Logging verbosity, e.g. `INFO`, `DEBUG`, `WARNING`.                         |
+| `NAMESPACE`    | Text prepended to the department name in every log entry.                   |
+| `GUI_LOG_PATH` | Override the log forwarding file (defaults to `<repo>/logs/gui.log`).       |
+
+All log messages are written to the console with colour formatting and mirrored to
+`GUI_LOG_PATH` when provided.
+
 ## Using bash structure exec
 
 ```bash

--- a/python/__init__.py
+++ b/python/__init__.py
@@ -1,1 +1,5 @@
-# __init__.py
+"""Public Python API for the Oliver Framework package."""
+
+from .utils.logging import Logger, getlogger, set_log_file
+
+__all__ = ["Logger", "getlogger", "set_log_file"]

--- a/python/utils/__init__.py
+++ b/python/utils/__init__.py
@@ -1,1 +1,5 @@
-# utils/__init__.py
+"""Utility helpers bundled with the Oliver Framework Python package."""
+
+from .logging import Logger, getlogger, set_log_file
+
+__all__ = ["Logger", "getlogger", "set_log_file"]

--- a/python/utils/logging.py
+++ b/python/utils/logging.py
@@ -130,12 +130,25 @@ class Logger:
             reset=True,
             style="%",
         )
-        handler = logging.StreamHandler()
-        handler.setFormatter(formatter)
 
-        if self._logger.handlers:
-            self._logger.handlers.clear()
-        self._logger.addHandler(handler)
+        default_handler = None
+        handlers_to_remove = []
+        for handler in self._logger.handlers:
+            if getattr(handler, "_oliver_default", False):
+                if default_handler is None:
+                    default_handler = handler
+                else:
+                    handlers_to_remove.append(handler)
+
+        for handler in handlers_to_remove:
+            self._logger.removeHandler(handler)
+
+        if default_handler is None:
+            default_handler = logging.StreamHandler()
+            setattr(default_handler, "_oliver_default", True)
+            self._logger.addHandler(default_handler)
+
+        default_handler.setFormatter(formatter)
 
     def _write_gui_log(self, msg: str) -> None:
         _ensure_parent(GUI_LOG_PATH)

--- a/python/utils/logging.py
+++ b/python/utils/logging.py
@@ -1,107 +1,163 @@
+"""Colorized logging utilities for Oliver Framework."""
+
+from __future__ import annotations
+
+import datetime as _dt
 import logging
 import os
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import ClassVar, Dict, Iterable, Union
+
 import colorlog
-import random
-import datetime
 from dotenv import load_dotenv
 
-env_path = os.getcwd() + '/.env'
-# Configure the logger with common settings
-load_dotenv(env_path)
-log_level = os.getenv('LOGGINGLEVEL', 'INFO')
+
+BASE_DIR = Path.cwd()
+ENV_PATH = BASE_DIR / ".env"
+if ENV_PATH.exists():
+    load_dotenv(ENV_PATH)
+
+LOG_LEVEL = os.getenv("LOGGINGLEVEL", "INFO").upper()
+NAMESPACE = os.getenv("NAMESPACE", "").strip()
+
 logging.basicConfig(
-    level=log_level,
-    format='%(asctime)s - [%(levelname)s] - %(message)s',
-    datefmt='%Y-%m-%d %H:%M:%S'
+    level=LOG_LEVEL,
+    format="%(asctime)s - [%(levelname)s] - %(message)s",
+    datefmt="%Y-%m-%d %H:%M:%S",
 )
 
-# Create a logger instance
-logger = colorlog.getLogger()
-# logger = logging.getLogger("logging")
-gui_log = os.path.join(os.getcwd(), "logs", "gui.log")
+LOGGER = colorlog.getLogger("oliver")
+LOGGER.setLevel(LOG_LEVEL)
+LOGGER.propagate = False
 
+
+def _default_log_path() -> Path:
+    """Return the default path used for GUI log forwarding."""
+
+    return BASE_DIR / "logs" / "gui.log"
+
+
+GUI_LOG_PATH: Path = (
+    Path(env_path)
+    if (env_path := os.getenv("GUI_LOG_PATH"))
+    else _default_log_path()
+)
+
+
+def set_log_file(log_file: Union[os.PathLike[str], str]) -> None:
+    """Override the log forwarding path used by :class:`Logger`."""
+
+    global GUI_LOG_PATH
+    GUI_LOG_PATH = Path(log_file)
+
+
+def _ensure_parent(path: Path) -> None:
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+    except OSError:
+        # Creating the directory is best-effort. The logger will surface IO errors later.
+        pass
+
+
+def _format_args(args: Iterable[object]) -> str:
+    return "" if not args else " " + " ".join(str(arg) for arg in args)
+
+
+@dataclass
 class Logger:
-    # Store color map for departments
-    department_colors = {}
+    """Small adapter around :mod:`logging` that adds colour and prefixes."""
 
-    def set_log_file(log_file):
-       gui_log = log_file
-    
-    def __init__(self, department):
-        self.department = department
-        self.extra = {'department': self.department}
-        self.prefix = f"[{department}] "
-        
-        # Set the color for the department if not already set
-        if department not in Logger.department_colors:
-            Logger.department_colors[department] = {
-                'DEBUG': 'purple',
-                'INFO': 'green',
-                'WARNING': 'yellow',
-                'ERROR': 'red',
-                'CRITICAL': 'red',
+    department: str
+    namespace: str = field(default=NAMESPACE, repr=False)
+    _logger: logging.Logger = field(default=LOGGER, init=False, repr=False)
+    extra: Dict[str, str] = field(init=False)
+    prefix: str = field(init=False)
+
+    department_colors: ClassVar[Dict[str, Dict[str, str]]] = {}
+
+    def __post_init__(self) -> None:
+        self.extra = {"department": self.department}
+        namespace = self.namespace
+        self.prefix = f"[{namespace}-{self.department}] " if namespace else f"[{self.department}] "
+        if self.department not in self.department_colors:
+            self.department_colors[self.department] = {
+                "DEBUG": "purple",
+                "INFO": "green",
+                "WARNING": "yellow",
+                "ERROR": "red",
+                "CRITICAL": "red",
             }
-        
-        # Set up colorlog's formatter and handler
-        self.update_color()
-        
-    def add_handler(self, handler):
-        logger.addHandler(handler)
+        self._configure_handler()
 
-    def update_color(self):
+    # Public API ---------------------------------------------------------
+    def add_handler(self, handler: logging.Handler) -> None:
+        self._logger.addHandler(handler)
+
+    def debug(self, msg: str, *args: object) -> None:
+        message = self._compose_message(msg, args)
+        self._logger.debug(message, extra=self.extra)
+
+    def info(self, msg: str, *args: object) -> None:
+        message = self._compose_message(msg, args)
+        self._write_gui_log(message)
+        self._logger.info(message, extra=self.extra)
+
+    def warning(self, msg: str, *args: object) -> None:
+        message = self._compose_message(msg, args)
+        self._write_gui_log(message)
+        self._logger.warning(message, extra=self.extra)
+
+    def error(self, msg: str, *args: object) -> None:
+        message = self._compose_message(msg, args)
+        self._write_gui_log(message)
+        self._logger.error(message, extra=self.extra)
+
+    def critical(self, msg: str, *args: object) -> None:
+        message = self._compose_message(msg, args)
+        self._logger.critical(message, extra=self.extra)
+
+    # Internal helpers ---------------------------------------------------
+    def _compose_message(self, msg: str, args: Iterable[object]) -> str:
+        self._configure_handler()
+        return f"{self.prefix}{msg}{_format_args(args)}"
+
+    def _configure_handler(self) -> None:
         formatter = colorlog.ColoredFormatter(
-            '%(log_color)s%(asctime)s - [%(levelname)s] - %(message)s%(reset)s',
-            datefmt='%Y-%m-%d %H:%M:%S',
-            log_colors=Logger.department_colors[self.department],
+            "%(log_color)s%(asctime)s - [%(levelname)s] - %(message)s%(reset)s",
+            datefmt="%Y-%m-%d %H:%M:%S",
+            log_colors=self.department_colors[self.department],
             reset=True,
-            style='%'
+            style="%",
         )
         handler = logging.StreamHandler()
         handler.setFormatter(formatter)
-        
-        ##  Clear existing handlers and set the new handler
-        logger.handlers[0] = handler
-        
-    def get_random_color(self):
-        colors = ['black, bg_white', 'red', 'green', 'yellow', 'blue', 'purple', 'cyan, bg_white']
-        color = random.choice(colors)
-        return color
-    
-    def debug(self, msg, *args):
-        self.update_color()
-        logger.debug(f"{self.prefix}{msg}{args if len(args) else ''}", extra=self.extra)
-        
-    def to_log(self, msg, *args):
-        # Try to open and write and close right away for other processes to work on this file
+
+        if self._logger.handlers:
+            self._logger.handlers.clear()
+        self._logger.addHandler(handler)
+
+    def _write_gui_log(self, msg: str) -> None:
+        _ensure_parent(GUI_LOG_PATH)
         try:
-            with open(gui_log, "a") as file:
-                current_time = datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')
-                file.write(f"{current_time} {msg} {args}\n")
-                # os.fsync(file.fileno())  # Flush the file buffer and force it to be written to disk
-        except OSError as e:
-            self.warning(f"Error opening or writing to {gui_log}: {e}")
+            with GUI_LOG_PATH.open("a", encoding="utf-8") as file:
+                current_time = _dt.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+                file.write(f"{current_time} {msg}\n")
+        except OSError as error:
+            # Avoid infinite recursion by calling the module level logger directly.
+            self._logger.warning(
+                "[%s] Error writing to %s: %s",
+                self.department,
+                GUI_LOG_PATH,
+                error,
+                extra=self.extra,
+            )
 
-    def info(self, msg, *args):
-        msg=f"{self.prefix}{msg}{args if len(args) else ''}"
-        self.update_color()
-        self.to_log(msg, *args)
-        logger.info(msg, extra=self.extra)
-        
-    def warning(self, msg, *args):
-        self.update_color()
-        self.to_log(msg, *args)
-        logger.warning(f"{self.prefix}{msg}{args if len(args) else ''}", extra=self.extra)
-        
-    def error(self, msg, *args):
-        self.update_color()
-        self.to_log(msg, *args)
-        logger.error(f"{self.prefix}{msg}{args if len(args) else ''}", extra=self.extra)
 
-    def critical(self, msg, *args):
-        self.update_color()
-        logger.critical(f"{self.prefix}{msg}{args if len(args) else ''}", extra=self.extra)
+def getlogger(department: str) -> Logger:
+    """Return a colour-aware :class:`Logger` for ``department``."""
 
-# Create other department loggers
-def getlogger(department):
-    logger.info(f"Initting log {gui_log}")
     return Logger(department)
+
+
+__all__ = ["Logger", "getlogger", "set_log_file"]

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='oliver_framework',
-    version='1.0.123',
+    version='1.1.0',
     packages=find_packages(),# ['oliver_framework.utils'],
     description='Oliver Python Framework',
     author='Oliver Huynh',


### PR DESCRIPTION
## Summary
- refactor the Python logger to support namespace-prefixed output and write logs safely
- expose the logging helpers through the package namespace and refresh the Python documentation
- bump the package version to 1.1.0

## Testing
- python -m compileall python

------
https://chatgpt.com/codex/tasks/task_e_69081f28842c83219c9ed9a7cec988e4